### PR TITLE
Support passing the team ID via k8s secrets

### DIFF
--- a/airplane-agent/Chart.yaml
+++ b/airplane-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: airplane-agent
 description: Airplane agents running with kubernetes driver
 type: application
-version: 2.2.0
+version: 2.3.0
 appVersion: 1

--- a/airplane-agent/templates/deployment.yaml
+++ b/airplane-agent/templates/deployment.yaml
@@ -40,7 +40,15 @@ spec:
               value: ""
               {{- end }}
             - name: AP_TEAM_ID
+              {{- if .Values.airplane.teamID }}
               value: "{{ .Values.airplane.teamID }}"
+              {{- else if .Values.airplane.teamIDSecret.name }}
+              valueFrom:
+                secretKeyRef:
+                  {{- toYaml .Values.airplane.teamIDSecret | nindent 18 }}
+              {{- else }}
+              value: ""
+              {{- end }}
             - name: AP_API_HOST
               value: "{{ .Values.airplane.apiHost }}"
             - name: AP_DRIVER
@@ -81,9 +89,9 @@ spec:
               value: "{{ .Values.sentry.environment }}"
             - name: AP_LOCK_KEY
               {{- if .Values.airplane.randomLockID }}
-              value: "helm-{{ .Values.airplane.randomLockID }}-{{ .Values.airplane.teamID }}"
+              value: "helm-{{ .Values.airplane.randomLockID }}"
               {{- else }}
-              value: "helm-{{ uuidv4 }}-{{ .Values.airplane.teamID }}"
+              value: "helm-{{ uuidv4 }}"
               {{- end }}
             - name: AP_ENV_SLUG
               value: "{{ .Values.airplane.envSlug }}"

--- a/airplane-agent/values.yaml
+++ b/airplane-agent/values.yaml
@@ -6,7 +6,11 @@ airplane:
   apiTokenSecret:
     name: ""
     key: ""
+  # Specify either teamID or teamIDSecret, not both
   teamID: ""
+  teamIDSecret:
+    name: ""
+    key: ""
 
   agentLabels: {}
   runNamespace: default


### PR DESCRIPTION
This change allows the team ID to be configured similarly to the API token which can simplify automation.

As a result of this change, remove team ID from the lock ID suffix as it is not always available.