### PR TITLE
Set sane resource constraint defaults

### DIFF
--- a/airplane-agent/Chart.yaml
+++ b/airplane-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: airplane-agent
 description: Airplane agents running with kubernetes driver
 type: application
-version: 2.3.1
+version: 2.3.2
 appVersion: 1

--- a/airplane-agent/values.yaml
+++ b/airplane-agent/values.yaml
@@ -82,6 +82,13 @@ serviceAccount:
   create: true
   annotations: {}
 
+resources:
+  limits:
+    memory: 96Mi
+  requests:
+    cpu: 100m
+    memory: 96Mi
+
 podSecurityContext: {}
 
 securityContext: {}


### PR DESCRIPTION
* Set resource request defaults to reserve capacity for the airplane agents.
* Set a memory limit equal to the memory request to ensure the agent doesn't leak memory and cause other processes to crash.